### PR TITLE
Make fetching feed async

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__
+*.pyc


### PR DESCRIPTION
Made fetching the feed async, using 'aiohttp' and 'asyncio' libraries. Only 'aiohttp' requires an install asyncio is already party of python. Functionality wise nothing has been changed.

I added as many comments as I could, but let me know if I should add more details about the change.

Before the change it took an average of 106 seconds to parse all feeds, and is now down to around 6-7 seconds.

Oh an added a gitignore since it kept generating cache files.

Cheers!