### PR TITLE
stability fixes

### DIFF
--- a/news-analysis.py
+++ b/news-analysis.py
@@ -41,7 +41,7 @@ from itertools import count
 from timeit import default_timer as timer
 
 # Use testnet (change to True) or live (change to False)?
-testnet = False
+testnet = True
 
 # get binance key and secret from environment variables for testnet and live
 api_key_test = os.getenv('binance_api_stalkbot_testnet')


### PR DESCRIPTION
- easy switch between testnet and live
- for some crypto lot_size equals -1 and float.format doesn't like that, so I hardcoded it to equals 0 in these situations (client.create_order function has no problem with value formated with this lot_size)
- increased timeout value in get_feed_data function, which fixes getting some feeds for me
- client.create_test_order function is used only while using testnet, because leaving it on live occured to buy 2 time more QUANTITY then it should (at least for me)
- handle all types of exeptions while using client.create_order (and also print error) in buy and sell functions, so bugs that doesn't really matter wouldn't stop the bot
- sometimes printing successful order was throwing a bug that 'order' variable was empty, so added basic checks if it is not

With this changes bot is working lovely on my side even on live. 14 hours and still no bugs.
Earned 0.0004 BTC by that time 😄 